### PR TITLE
Beef up web server security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 ARG  PHP_VERSION
 FROM php:${PHP_VERSION}-apache
 
-# Copy the entrypoint program
-COPY entrypoint.sh /usr/local/bin/ 
+COPY entrypoint.sh /usr/local/bin/
 RUN  chmod +x /usr/local/bin/entrypoint.sh
+COPY security.conf /etc/apache2/conf-available/security.conf
 
 # Install composer
 COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
@@ -30,7 +30,7 @@ RUN set -ex; \
     docker-php-ext-configure gd --with-jpeg; \
     docker-php-ext-install mysqli gd ldap; \
     pecl install timezonedb; \
-    docker-php-ext-enable timezonedb
+    docker-php-ext-enable timezonedb;
 
 # Get application and customize
 USER www-data

--- a/security.conf
+++ b/security.conf
@@ -1,0 +1,56 @@
+# Changing the following options will not really affect the security of the
+# server, but might make attacks slightly more difficult in some cases.
+
+#
+# ServerTokens
+# This directive configures what you return as the Server HTTP response
+# Header. The default is 'Full' which sends information about the OS-Type
+# and compiled in modules.
+# Set to one of:  Full | OS | Minimal | Minor | Major | Prod
+# where Full conveys the most information, and Prod the least.
+ServerTokens Prod
+
+#
+# Optionally add a line containing the server version and virtual host
+# name to server-generated pages (internal error documents, FTP directory
+# listings, mod_status and mod_info output etc., but not CGI generated
+# documents or custom error documents).
+# Set to "EMail" to also include a mailto: link to the ServerAdmin.
+# Set to one of:  On | Off | EMail
+ServerSignature Off
+
+#
+# Allow TRACE method
+#
+# Set to "extended" to also reflect the request body (only for testing and
+# diagnostic purposes).
+#
+# Set to one of:  On | Off | extended
+TraceEnable Off
+
+#
+# Setting this header will prevent MSIE from interpreting files as something
+# else than declared by the content type in the HTTP headers.
+# Requires mod_headers to be enabled.
+#
+Header set X-Content-Type-Options: "nosniff"
+
+#
+# Setting this header will prevent other sites from embedding pages from this
+# site as frames. This defends against clickjacking attacks.
+# Requires mod_headers to be enabled.
+#
+Header set X-Frame-Options: "sameorigin"
+
+#
+# Setting this header will control how much information the browser includes
+# with navigations away from a document and should be set by all sites.
+#
+Header set Referrer-Policy: "no-referrer"
+
+#
+# Setting this header will control which features and APIs can be used
+# in the browser
+Header set permissions-policy: "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()"
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
1. Reduce apache verbosity
2. Add the following headers:
   - X-Content-Type-Options: "nosniff"
   - X-Frame-Options: "sameorigin"
   - Referrer-Policy: "no-referrer"
   - permissions-policy