### PR TITLE
Fix Issue 95

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 ARG  PHP_VERSION
 FROM php:${PHP_VERSION}-apache
 
-COPY entrypoint.sh /usr/local/bin/
-RUN  chmod +x /usr/local/bin/entrypoint.sh
-
 # Install composer
 COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
 
@@ -66,10 +63,11 @@ RUN set -ex; \
     chown www-data:www-data /app.log; \
     mkdir /config
 
-# Declarations
-VOLUME /config
-ENTRYPOINT ["entrypoint.sh"]
-CMD ["apache2-foreground"]
+# Environment
+WORKDIR    /
+VOLUME     /config
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD        ["apache2-foreground"]
 
 # Labels
 LABEL org.opencontainers.image.title="LibreBooking"
@@ -78,3 +76,7 @@ LABEL org.opencontainers.image.url="https://github.com/librebooking/docker"
 LABEL org.opencontainers.image.source="https://github.com/librebooking/docker"
 LABEL org.opencontainers.image.licenses="GPL-3.0"
 LABEL org.opencontainers.image.authors="robin.alexander@netplus.ch"
+
+# Set entrypoint
+COPY entrypoint.sh /usr/local/bin/
+RUN  chmod +x /usr/local/bin/entrypoint.sh

--- a/RUN.md
+++ b/RUN.md
@@ -16,6 +16,7 @@ Environment variables are used on first invocation of the container (when the fi
 | `LB_LOG_LEVEL` | none | debug | **No** | ['settings']['logging']['level'] |
 | `LB_LOG_SQL` | false | true | **No** | ['settings']['logging']['sql'] |
 | `LB_ENV` | production | dev | **No** | N/A - Used to initialize file config.php |
+| `LB_PATH` | - | book | **No** | N/A - URL path prefix (usually none) |
 
 ## Development environment: using the command line interface
 This simple setup is meant for testing the application within your private network.

--- a/RUN.md
+++ b/RUN.md
@@ -37,10 +37,7 @@ docker run \
   --env PUID=1000 \
   --env PGID=1000 \
   --env TZ=Europe/Zurich \
-  --env MYSQL_DATABASE=librebooking \
   --env MYSQL_ROOT_PASSWORD=your_Mariadb_root_password \
-  --env MYSQL_USER=lb_user \
-  --env MYSQL_PASSWORD=your_Mariadb_user_password \
   linuxserver/mariadb:10.6.13
 
 # Run librebooking
@@ -171,7 +168,6 @@ services:
       - PGID=1000
       - TZ=Europe/Zurich
       - FILE__MYSQL_ROOT_PASSWORD=/run/secrets/db_root_pwd
-      - FILE__MYSQL_PASSWORD=/run/secrets/db_user_pwd
     secrets:
       - db_root_pwd
       - db_user_pwd

--- a/RUN.md
+++ b/RUN.md
@@ -1,8 +1,10 @@
 # How to run the docker image
-The image contains the apache web server and the librebooking application files. It needs to be linked to a MariaDB database container.
+The image contains the apache web server and the librebooking application files.
+It needs to be linked to a MariaDB database container.
 
 ## Environment variables
-Environment variables are used on first invocation of the container (when the file config/config.php does not yet exist)
+Environment variables are used on first invocation of the container
+(when the file config/config.php does not yet exist)
 
 | Env | Default | Example | Required | config.php settings |
 | - | - | - | - | - |
@@ -64,30 +66,26 @@ docker run \
 ## Development environment: using docker compose
 This simple setup is meant for testing the application within your private network.
 
-Create a `docker-compose.yml` file from the following sample and adapt the value of the environment variables to your needs:
+Create a `docker-compose.yml` file from the following sample and adapt the
+value of the environment variables to your needs:
 ```
 version: "3.7"
 
 services:
   db:
     image: linuxserver/mariadb:10.6.13
-    container_name: librebooking-db
     restart: always
     networks:
       - mynet
     volumes:
-      - vol-db:/config
+      - db_conf:/config
     environment:
       - PUID=1000
       - PGID=1000
       - TZ=Europe/Zurich
-      - MYSQL_DATABASE=librebooking
       - MYSQL_ROOT_PASSWORD=your_Mariadb_root_password
-      - MYSQL_USER=lb_user
-      - MYSQL_PASSWORD=your_Mariadb_user_password
   app:
     image: librebooking/librebooking:develop
-    container_name: librebooking
     restart: always
     depends_on:
       - db
@@ -96,7 +94,7 @@ services:
     ports:
       - "80:80"
     volumes:
-      - vol-app:/config
+      - app_conf:/config
     environment: 
       - LB_DB_NAME=librebooking
       - LB_DB_USER=lb_user
@@ -110,10 +108,8 @@ services:
       - TZ=Europe/Zurich
 
 volumes:
-  vol-db:
-    name: librebooking_data
-  vol-app:
-    name: librebooking_conf
+  db_conf:
+  app_conf:
 
 networks:
   mynet:
@@ -126,8 +122,10 @@ docker-compose up --detach
 
 ## Production environment: using docker compose
 This setup is meant for accessing the application from the internet. It features:
-- The [traefik reverse proxy](https://traefik.io/traefik/) 
+- A reverse proxy based on nginx that automatically handle certificates 
 - The usage of secrets to pass passwords to the docker container
+- A librebooking service accessible without a URL-path (ex: https://librebooking.your-domain.com)
+- A librebooking service accessible with a URL-path (ex: https://your-domain.com/book)
 
 Create a `docker-compose.yml` file from the following sample and adapt the value of the environment variables to your needs:
 
@@ -136,62 +134,87 @@ version: "3.7"
 
 services:
   proxy:
-    image: traefik:2.10
-    container_name: traefik
+    image: nginxproxy/nginx-proxy
     restart: always
     networks:
-      mynet:
+      - mynet
     ports:
       - 80:80
       - 443:443
-      - 8080:8080
-    command:
-      - "--api.insecure=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:80"
-      - "--entrypoints.web.http.redirections.entryPoint.to=webs"
-      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
-      - "--entrypoints.webs.address=:443"
-      - "--certificatesresolvers.myresolver.acme.email=your@email"
-      - "--certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web"
     volumes:
-      - "vol-rproxy:/etc/traefik/acme"
-      - "/var/run/docker.sock:/var/run/docker.sock"
-  db:
-    image: linuxserver/mariadb:10.6.13
-    container_name: librebooking-db
+      - proxy_certs:/etc/nginx/certs
+      - proxy_html:/usr/share/nginx/html
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+  acme:
+    image: nginxproxy/acme-companion
     restart: always
     depends_on:
       - proxy
     networks:
       - mynet
+    volumes_from:
+      - proxy
     volumes:
-      - vol-db:/config
+      - acme_acme:/etc/acme.sh
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      - DEFAULT_EMAIL=colisee@hotmail.com
+  db:
+    image: linuxserver/mariadb:10.6.13
+    restart: always
+    networks:
+      - mynet
+    volumes:
+      - db_conf:/config
     environment:
       - PUID=1000
       - PGID=1000
       - TZ=Europe/Zurich
-      - MYSQL_DATABASE=librebooking
       - FILE__MYSQL_ROOT_PASSWORD=/run/secrets/db_root_pwd
-      - MYSQL_USER=lb_user
       - FILE__MYSQL_PASSWORD=/run/secrets/db_user_pwd
     secrets:
       - db_root_pwd
       - db_user_pwd
-  app:
-    image: librebooking/librebooking:2.8.6.1
-    container_name: librebooking
+  lb1:
+    image: librebooking/librebooking:2.8.6.2
     restart: always
     depends_on:
       - db
     networks:
       - mynet
     volumes:
-      - vol-app:/config
-    environment: 
-      - LB_DB_NAME=librebooking
+      - lb1_conf:/config
+    environment:
+      - LB_DB_NAME=lb1
       - LB_INSTALL_PWD_FILE=/run/secrets/lb_install_pwd
-      - LB_DB_USER=lb_user
+      - LB_DB_USER=lb1
+      - LB_DB_USER_PWD_FILE=/run/secrets/lb_user_pwd
+      - LB_DB_HOST=db
+      - LB_ENV=production
+      - LB_LOG_FOLDER=/var/log/librebooking
+      - LB_LOG_LEVEL=error
+      - LB_LOG_SQL=false
+      - LB_PATH=lb1
+      - TZ=Europe/Zurich
+      - VIRTUAL_HOST=your_host_com
+      - VIRTUAL_PATH=/your_path
+      - LETSENCRYPT_HOST=your_host_com
+    secrets:
+      - lb_install_pwd
+      - lb_user_pwd
+  lb2:
+    image: librebooking/librebooking:2.8.6.2
+    restart: always
+    depends_on:
+      - db
+    networks:
+      - mynet
+    volumes:
+      - lb2_conf:/config
+    environment:
+      - LB_DB_NAME=lb2
+      - LB_INSTALL_PWD_FILE=/run/secrets/lb_install_pwd
+      - LB_DB_USER=lb2
       - LB_DB_USER_PWD_FILE=/run/secrets/lb_user_pwd
       - LB_DB_HOST=db
       - LB_ENV=production
@@ -199,43 +222,39 @@ services:
       - LB_LOG_LEVEL=error
       - LB_LOG_SQL=false
       - TZ=Europe/Zurich
-
+      - VIRTUAL_HOST=your_host_com
+      - LETSENCRYPT_HOST=your_host_com
     secrets:
       - lb_install_pwd
       - lb_user_pwd
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.librebooking.rule=Host(`www.domain.com`)"
-      - "traefik.http.routers.librebooking.tls.certresolver=myresolver"
-      - "traefik.http.services.librebooking.loadbalancer.server.port=80"
 
 volumes:
-  vol-rproxy:
-    name: traefik_certs
-  vol-db:
-    name: librebooking_data
-  vol-app:
-    name: librebooking_conf
+  proxy_certs:
+  proxy_html:
+  acme_acme:
+  db_conf:
+  lb1_conf:
+  lb2_conf:
 
 networks:
   mynet:
 
 secrets:
   db_root_pwd:
-    file: ./db_root_pwd.txt
+    file: ./pwd_db_root.txt
   db_user_pwd:
-    file: ./db_user_pwd.txt
+    file: ./pwd_db_user.txt
   lb_user_pwd:
-    file: ./db_user_pwd.txt
+    file: ./pwd_db_user.txt
   lb_install_pwd:
-    file: ./lb_install_pwd.txt
+    file: ./pwd_lb_inst.txt
 ```
 
 Set the secrets with the following commands:
 ```
-echo -n 'your_Mariadb_root_password' > db_root_pwd.txt;
-echo -n 'your_Mariadb_user_password' > db_user_pwd.txt;
-echo -n 'your_Librebooking_installation_password' > lb_install_pwd.txt;
+echo -n 'your_Mariadb_root_password'              > pwd_db_root.txt;
+echo -n 'your_Mariadb_user_password'              > pwd_db_user.txt;
+echo -n 'your_Librebooking_installation_password' > pwd_lb_inst.txt;
 ```
 Start the application with the following command:
 ```

--- a/SETUP.md
+++ b/SETUP.md
@@ -3,7 +3,8 @@
 ## First-time fresh install
 
 ### Database initialization
-1. Point your web browser to `http://<YOUR_HOST>/Web/install`
+1. Point your web browser to `<YOUR_HOST>/install` or `<YOUR_HOST>/<YOUR_PATH>/install`
+(if you are using a custom URL-path)
    - Enter the installation password (docker variable `LB_INSTALL_PWD`)
    - Enter the database root user: `root`
    - Enter the database root password (docker variable `LB_DB_USER_PWD`)
@@ -14,7 +15,7 @@
    - Click on the button `Register`
 
 ### Application configuration
-1. Point your web browser to `http://<YOUR_HOST>` or `https://<YOUR_HOST>`
+1. Point your web browser to `<YOUR_HOST>` or `<YOUR_HOST>/<YOUR_PATH>`
 if you are using a reverse-proxy
 1. Login with your application administrator profile
 1. Configure the web application
@@ -29,7 +30,8 @@ if you are using a reverse-proxy
    ```
    docker-compose up --detach
    ```
-1. Upgrade the application database by pointing your web browser to `http://<YOUR_HOST>/Web/install/configure.php`
+1. Upgrade the application database by accessing `<YOUR_HOST>/install/configure.php`
+or `<YOUR_HOST>/<YOUR_PATH>/install/configure.php`
 
 ## Upgrade to docker-image v2 from docker-image v1
 1. Stop the service

--- a/SETUP.md
+++ b/SETUP.md
@@ -8,12 +8,14 @@
    - Enter the database root user: `root`
    - Enter the database root password (docker variable `LB_DB_USER_PWD`)
    - Select `Create the database`
+   - Select `Create the database user`
    - Click on the register link, at the bottom of the web page
    - Fill the register form for the application administrator
    - Click on the button `Register`
 
 ### Application configuration
-1. Point your web browser to `http://<YOUR_HOST>`
+1. Point your web browser to `http://<YOUR_HOST>` or `https://<YOUR_HOST>`
+if you are using a reverse-proxy
 1. Login with your application administrator profile
 1. Configure the web application
 


### PR DESCRIPTION
Add the possibility to use a custom path when:
- one need to differentiate several running librebooking containers
- it is not possible to differentiate containers with different hosts

Enhance the documentation file `RUN.md`